### PR TITLE
FIX: Don't return stack-allocated character buffer to Vim.

### DIFF
--- a/misc/shell/shell.c
+++ b/misc/shell/shell.c
@@ -65,6 +65,7 @@ static const char *Failure(const char *result) /* {{{1 */
 	return result;
 }
 
+char rv[500];
 static const char *execute(char *command, int wait) /* {{{1 */
 {
 	STARTUPINFO si;
@@ -76,7 +77,6 @@ static const char *execute(char *command, int wait) /* {{{1 */
 		if (!wait) {
 			return Success(NULL);
 		} else {
-			char rv[500];
 			DWORD exit_code;
 			if (WaitForSingleObject(pi.hProcess, INFINITE) != WAIT_FAILED
 				 	&& GetExitCodeProcess(pi.hProcess, &exit_code)


### PR DESCRIPTION
This fixes #13 for me, but please review; it's been some time since I've seriously written C code, so I'm a bit rusty :-)

Thanks for looking so quickly into the issue I've submitted; I agree that your `sprintf()` change in aac1374 is correct, but that alone didn't change the symptoms of the problem at all. Fortunately, I have a minimal build environment, and I was able to get the DLL working by fiddling with the code, around what you've recently changed there.

The function-local `rv` string is allocated on the stack, that seems to work by pure chance in 32-bit, but fails in 64-bit. A simple fix is to make it a static string.
